### PR TITLE
Changed method to use ClassLoader to load needed resources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - sprint-1
       - sprint-2
+      - sprint-3
       - main
 
 jobs:

--- a/market-service/src/main/java/rs/edu/raf/banka1/utils/Constants.java
+++ b/market-service/src/main/java/rs/edu/raf/banka1/utils/Constants.java
@@ -16,7 +16,7 @@ public class Constants {
     public static final String countryTimezoneOffsetsFilePath = getAbsoluteFilePath(
             "country_timezone_offsets.json");
     public static final List<String> sectors = List.of(
-            "Technology","Electronic Technology","Health Technology","Health Services","Finance","Energy");
+            "Technology", "Electronic Technology", "Health Technology", "Health Services", "Finance", "Energy");
     public static final int maxStockListings = 20;
     public static final int maxStockListingsHistory = 10;
     public static String optionsFilePath = getAbsoluteFilePath(
@@ -45,11 +45,12 @@ public class Constants {
     public static String getAbsoluteFilePath(String relativePath) {
         try {
             Resource resource = new ClassPathResource(relativePath);
-            if(resource.exists())
+            if (resource.exists()) {
                 return resource.getURL().getPath();
-            else
+            } else {
                 System.out.println("[Constants getAbsoluteFilePath] Resource does not exist: " + relativePath);
-        } catch (IOException e){
+            }
+        } catch (IOException e) {
             System.err.println("[Constants getAbsoluteFilePath] Cannot load resource whose relative path is " + relativePath);
         }
         return null;

--- a/market-service/src/main/java/rs/edu/raf/banka1/utils/Constants.java
+++ b/market-service/src/main/java/rs/edu/raf/banka1/utils/Constants.java
@@ -1,22 +1,26 @@
 package rs.edu.raf.banka1.utils;
 
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
 import java.util.List;
 
 public class Constants {
     public static final String listingsFilePath = getAbsoluteFilePath(
-            "market-service/src/main/resources/listings.json");
+            "listings.json");
     public static final String businessHoursFilePath = getAbsoluteFilePath(
-            "market-service/src/main/resources/working_hours_and_holidays_for_exchanges.json");
+            "working_hours_and_holidays_for_exchanges.json");
     public static final String micCsvFilePath = getAbsoluteFilePath(
-            "market-service/src/main/resources/ISO10383_MIC.csv");
+            "ISO10383_MIC.csv");
     public static final String countryTimezoneOffsetsFilePath = getAbsoluteFilePath(
-            "market-service/src/main/resources/country_timezone_offsets.json");
+            "country_timezone_offsets.json");
     public static final List<String> sectors = List.of(
             "Technology","Electronic Technology","Health Technology","Health Services","Finance","Energy");
     public static final int maxStockListings = 20;
     public static final int maxStockListingsHistory = 10;
     public static String optionsFilePath = getAbsoluteFilePath(
-            "market-service/src/main/resources/options.json");
+            "options.json");
 //    public static final List<String> sectors = List.of("Technology");
     public static List<String> tickersForTestingOptions = List.of("APPL", "ORCL", "MSFT", "VXX");
     public static final int maxListings = 700;
@@ -35,10 +39,19 @@ public class Constants {
             "FLUXF");
 
     public static String currencyFilePath = getAbsoluteFilePath(
-            "market-service/src/main/resources/physical_currency_list.csv");
+            "physical_currency_list.csv");
 
 
     public static String getAbsoluteFilePath(String relativePath) {
-        return System.getProperty("user.dir") + "/" + relativePath;
+        try {
+            Resource resource = new ClassPathResource(relativePath);
+            if(resource.exists())
+                return resource.getURL().getPath();
+            else
+                System.out.println("[Constants getAbsoluteFilePath] Resource does not exist: " + relativePath);
+        } catch (IOException e){
+            System.err.println("[Constants getAbsoluteFilePath] Cannot load resource whose relative path is " + relativePath);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Hello team,
This time, I have changed getAbsoluteFilePath method inside Constants file to use Spring's ClassLoader to load needed resources instead of System.getProperty("user.dir") + ... 
The difference between these approaches is that ClassLoader option provides flexibility since it uses ClassLoader to find and load needed resource. System.getProperty() uses machines FS in order to build the path.

Method was tested locally and showed no errors.

Also, I've changed deploy.yml to use sprint-3 as trigger branch and CURRENT_BRANCH env var was changed in repository secrets.

If there are any changes to be requested I will be more than happy to discuss.

Best,
Vid