### PR TITLE
Changed resource loading to use classloader

### DIFF
--- a/market-service/src/main/java/rs/edu/raf/banka1/bootstrap/BootstrapData.java
+++ b/market-service/src/main/java/rs/edu/raf/banka1/bootstrap/BootstrapData.java
@@ -129,15 +129,7 @@ public class BootstrapData implements CommandLineRunner {
         BufferedReader br = null;
 
         try {
-            Resource resource = null;
-
-            if(environment){
-                resource = new ClassPathResource(currencyFilePath);
-            }
-            else {
-                String fileStr = currencyFilePath.substring(currencyFilePath.lastIndexOf("/") + 1);
-                resource = new ClassPathResource("classpath:" + fileStr, this.getClass().getClassLoader());
-            }
+            Resource resource = new ClassPathResource(currencyFilePath, this.getClass().getClassLoader());
 
             InputStream in = resource.getInputStream();
             InputStreamReader inputStreamReader = new InputStreamReader(in);
@@ -158,6 +150,7 @@ public class BootstrapData implements CommandLineRunner {
             }
         } catch (IOException e) {
             e.printStackTrace();
+            Logger.error("[BootstrapData] Caught exception " + e.getMessage());
         } finally {
             try {
                 if(br != null) {

--- a/market-service/src/main/java/rs/edu/raf/banka1/bootstrap/BootstrapData.java
+++ b/market-service/src/main/java/rs/edu/raf/banka1/bootstrap/BootstrapData.java
@@ -50,8 +50,6 @@ public class BootstrapData implements CommandLineRunner {
     @Autowired
     private final ExchangeService exchangeService;
 
-    private static final Boolean environment = Boolean.parseBoolean(System.getProperty("dev.environment", "true"));
-
     @Override
     public void run(String... args) throws Exception {
         Logger.info("Loading Data...");

--- a/market-service/src/main/java/rs/edu/raf/banka1/services/ExchangeServiceImpl.java
+++ b/market-service/src/main/java/rs/edu/raf/banka1/services/ExchangeServiceImpl.java
@@ -48,10 +48,6 @@ public class ExchangeServiceImpl implements ExchangeService {
     private final ExchangeRepository exchangeRepository;
     private final ExchangeMapper exchangeMapper;
 
-
-    @Value("${dev.environment}")
-    private Boolean environment;
-
     @Autowired
     public ExchangeServiceImpl(
             CountryRepository countryRepository,

--- a/market-service/src/main/java/rs/edu/raf/banka1/services/ExchangeServiceImpl.java
+++ b/market-service/src/main/java/rs/edu/raf/banka1/services/ExchangeServiceImpl.java
@@ -39,6 +39,7 @@ import java.util.Date;
 
 import static rs.edu.raf.banka1.utils.Constants.businessHoursFilePath;
 import static rs.edu.raf.banka1.utils.Constants.countryTimezoneOffsetsFilePath;
+import static rs.edu.raf.banka1.utils.Constants.micCsvFilePath;
 
 @Service
 public class ExchangeServiceImpl implements ExchangeService {
@@ -90,15 +91,9 @@ public class ExchangeServiceImpl implements ExchangeService {
 //        try (CSVReader reader = new CSVReader(new FileReader(Constants.micCsvFilePath))) {
         try {
 
-            if (this.environment) {
-                reader = new CSVReader(new FileReader(Constants.micCsvFilePath));
-            } else {
-                String classpath = "classpath:" + Constants.micCsvFilePath
-                        .substring(Constants.micCsvFilePath.lastIndexOf("/") + 1);
-                resource = new ClassPathResource(classpath);
-                InputStream in = resource.getInputStream();
-                reader = new CSVReader(new InputStreamReader(in));
-            }
+            resource = new ClassPathResource(micCsvFilePath, this.getClass().getClassLoader());
+            InputStream in = resource.getInputStream();
+            reader = new CSVReader(new InputStreamReader(in));
 
             // e.g. 17:00:00
             SimpleDateFormat hoursDateFormat = new SimpleDateFormat("HH:mm:ss");
@@ -146,6 +141,7 @@ public class ExchangeServiceImpl implements ExchangeService {
             saveAllHolidays(countryIsoToCountryMap, countryIsoToAllHolidayDatesMap);
         } catch (IOException | CsvValidationException | ParseException e) {
             e.printStackTrace();
+            Logger.error("[ExchangeSericeImpl] Caught exception during " + e.getMessage());
         } finally {
             try {
                 if (reader != null) {
@@ -199,17 +195,11 @@ public class ExchangeServiceImpl implements ExchangeService {
             ObjectMapper mapper = new ObjectMapper();
             mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-            if (this.environment) {
-                countryTimezones = mapper.readValue(new File(countryTimezoneOffsetsFilePath), CountryTimezoneDto[].class);
-            } else {
-                String classpath = "classpath:" + countryTimezoneOffsetsFilePath
-                        .substring(countryTimezoneOffsetsFilePath.lastIndexOf("/") + 1);
-
-                resource = new ClassPathResource(classpath);
-                countryTimezones = mapper.readValue(resource.getInputStream(), CountryTimezoneDto[].class);
-            }
+            resource = new ClassPathResource(countryTimezoneOffsetsFilePath, this.getClass().getClassLoader());
+            countryTimezones = mapper.readValue(resource.getInputStream(), CountryTimezoneDto[].class);
         } catch (IOException e) {
             e.printStackTrace();
+            Logger.error("[ExchangeServiceImpl] Caught exception " + e.getMessage());
         }
 
         return countryTimezones;
@@ -220,21 +210,17 @@ public class ExchangeServiceImpl implements ExchangeService {
         Resource resource = null;
 
         try {
+
             ObjectMapper mapper = new ObjectMapper();
-            if (this.environment) {
-                resultMap = mapper.readValue(new File(businessHoursFilePath), HashMap.class);
-            } else {
-                String classpath = "classpath:" + businessHoursFilePath
-                        .substring(businessHoursFilePath.lastIndexOf("/") + 1);
-                resource = new ClassPathResource(classpath);
-                resultMap = mapper.readValue(resource.getInputStream(), HashMap.class);
-            }
+            resource = new ClassPathResource(businessHoursFilePath, this.getClass().getClassLoader());
+            resultMap = mapper.readValue(resource.getInputStream(), HashMap.class);
 
             for (Map.Entry<String, BusinessHoursDto> entry : resultMap.entrySet()) {
                 resultMap.put(entry.getKey(), mapper.convertValue(entry.getValue(), BusinessHoursDto.class));
             }
         } catch (IOException e) {
             e.printStackTrace();
+            Logger.error("[ExchangeServiceImpl] Caught exception " + e.getMessage());
         }
 
         return resultMap;

--- a/market-service/src/main/java/rs/edu/raf/banka1/utils/Constants.java
+++ b/market-service/src/main/java/rs/edu/raf/banka1/utils/Constants.java
@@ -8,22 +8,32 @@ import java.io.IOException;
 import java.util.List;
 
 public class Constants {
-    public static final String listingsFilePath = getAbsoluteFilePath(
-            "listings.json");
-    public static final String businessHoursFilePath = getAbsoluteFilePath(
-            "working_hours_and_holidays_for_exchanges.json");
-    public static final String micCsvFilePath = getAbsoluteFilePath(
-            "ISO10383_MIC.csv");
-    public static final String countryTimezoneOffsetsFilePath = getAbsoluteFilePath(
-            "country_timezone_offsets.json");
+    public static final String listingsFilePath =
+            "listings.json";
+    public static final String businessHoursFilePath =
+            "working_hours_and_holidays_for_exchanges.json";
+    public static final String micCsvFilePath =
+            "ISO10383_MIC.csv";
+    public static final String countryTimezoneOffsetsFilePath =
+            "country_timezone_offsets.json";
+//    public static final String listingsFilePath = getAbsoluteFilePath(
+//            "listings.json");
+//    public static final String businessHoursFilePath = getAbsoluteFilePath(
+//            "working_hours_and_holidays_for_exchanges.json");
+//    public static final String micCsvFilePath = getAbsoluteFilePath(
+//            "ISO10383_MIC.csv");
+//    public static final String countryTimezoneOffsetsFilePath = getAbsoluteFilePath(
+//            "country_timezone_offsets.json");
     public static final List<String> sectors = List.of(
             "Technology", "Electronic Technology", "Health Technology", "Health Services", "Finance", "Energy");
     public static final int maxStockListings = 20;
     public static final int maxStockListingsHistory = 10;
     public static final int maxFutures = 10;
     public static final int maxFutureHistories = 20;
-    public static final String optionsFilePath = getAbsoluteFilePath(
-            "options.json");
+//    public static final String optionsFilePath = getAbsoluteFilePath(
+//            "options.json");
+    public static final String optionsFilePath =
+            "options.json";
     //    public static final List<String> sectors = List.of("Technology");
     public static List<String> tickersForTestingOptions = List.of("AAPL", "ORCL", "MSFT", "VXX");
     public static final int maxListings = 700;
@@ -41,21 +51,23 @@ public class Constants {
             "ATMQF",
             "FLUXF");
 
-    public static final String currencyFilePath = getAbsoluteFilePath(
-            "physical_currency_list.csv");
+//    public static final String currencyFilePath = getAbsoluteFilePath(
+//            "physical_currency_list.csv");
+    public static final String currencyFilePath =
+        "physical_currency_list.csv";
 
 
-    public static String getAbsoluteFilePath(String relativePath) {
-        try {
-            Resource resource = new ClassPathResource(relativePath);
-            if (resource.exists()) {
-                return resource.getURL().getPath().replaceAll("%20", " ");
-            } else {
-                Logger.warn("Resource does not exist: " + relativePath);
-            }
-        } catch (IOException e) {
-            Logger.error(e, "Cannot load resource whose relative path is " + relativePath);
-        }
-        return null;
-    }
+//    public static String getAbsoluteFilePath(String relativePath) {
+//        try {
+//            Resource resource = new ClassPathResource(relativePath);
+//            if (resource.exists()) {
+//                return resource.getURL().getPath().replaceAll("%20", " ");
+//            } else {
+//                Logger.warn("Resource does not exist: " + relativePath);
+//            }
+//        } catch (IOException e) {
+//            Logger.error(e, "Cannot load resource whose relative path is " + relativePath);
+//        }
+//        return null;
+//    }
 }


### PR DESCRIPTION
Hello team,
During this task I was able to fix the problem with relative paths which occurred during the run phase of the container.
Before, market service wasn't able to start normally because CSV and JSON files which are used for bulk insertion weren't available. 

The thing is that packed files inside final jar (app.jar) are located inside the target/classes/ folder (same thing for local machines). In these files are included resources also. 

When trying to read files, it's better to load them as new ClassPathResource(path, this.getClass().getClassLoader()) and then obtain InputStream from the loaded resource using .getInputStream(). 
Then pass input stream to any reader to proceed with reading logic.

Important thing to mention is to always use filenames only, without any path because if original files are only located in resources folder, not in any subdirectory inside resources, class loader will access them from classpath. If file is located in subdirectory, use <subdir_name>/<file_name>.<ext>.

Best,
Vid



